### PR TITLE
Ivelez/add href to nav links

### DIFF
--- a/completed.html
+++ b/completed.html
@@ -37,12 +37,15 @@
         </div>
         <nav>
 			<ul class = "nav-menu">
-				<li class = "nav-item"></li>
+				<li class = "nav-item">
 					<a href="#" class = "nav-link">Home</a>
-				<li class = "nav-item"></li>
+                </li>
+				<li class = "nav-item">
 					<a href="#" class = "nav-link">Completed Exercise</a>
-				<li class = "nav-item"></li>
+                </li>
+				<li class = "nav-item">
 					<a href="#" class = "nav-link">Favorited</a>
+                </li>
 			</ul>
 			<div class = "hamburger">
 				<span class = "bar"></span>

--- a/completed.html
+++ b/completed.html
@@ -38,13 +38,13 @@
         <nav>
 			<ul class = "nav-menu">
 				<li class = "nav-item">
-					<a href="#" class = "nav-link">Home</a>
+					<a href="/homepage/index.html" class = "nav-link">Home</a>
                 </li>
 				<li class = "nav-item">
-					<a href="#" class = "nav-link">Completed Exercise</a>
+					<a href="completed.html" class = "nav-link">Completed Exercise</a>
                 </li>
 				<li class = "nav-item">
-					<a href="#" class = "nav-link">Favorited</a>
+					<a href="favorite.html" class = "nav-link">Favorited</a>
                 </li>
 			</ul>
 			<div class = "hamburger">

--- a/favorite.html
+++ b/favorite.html
@@ -36,12 +36,15 @@
         </div>
         <nav>
 			<ul class = "nav-menu">
-				<li class = "nav-item"></li>
+				<li class = "nav-item">
 					<a href="#" class = "nav-link">Home</a>
-				<li class = "nav-item"></li>
+                </li>
+				<li class = "nav-item">
 					<a href="#" class = "nav-link">Completed Exercise</a>
-				<li class = "nav-item"></li>
+                </li>
+				<li class = "nav-item">
 					<a href="#" class = "nav-link">Favorited</a>
+                </li>
 			</ul>
 			<div class = "hamburger">
 				<span class = "bar"></span>

--- a/favorite.html
+++ b/favorite.html
@@ -37,13 +37,13 @@
         <nav>
 			<ul class = "nav-menu">
 				<li class = "nav-item">
-					<a href="#" class = "nav-link">Home</a>
+					<a href="/homepage/index.html" class = "nav-link">Home</a>
                 </li>
 				<li class = "nav-item">
-					<a href="#" class = "nav-link">Completed Exercise</a>
+					<a href="completed.html" class = "nav-link">Completed Exercise</a>
                 </li>
 				<li class = "nav-item">
-					<a href="#" class = "nav-link">Favorited</a>
+					<a href="favorite.html" class = "nav-link">Favorited</a>
                 </li>
 			</ul>
 			<div class = "hamburger">

--- a/homepage/index.html
+++ b/homepage/index.html
@@ -22,12 +22,15 @@
 			</div>
 			<nav>
 				<ul class = "nav-menu">
-					<li class = "nav-item"></li>
+					<li class = "nav-item">
 						<a href="#" class = "nav-link">Home</a>
-					<li class = "nav-item"></li>
+					</li>
+					<li class = "nav-item">
 						<a href="#" class = "nav-link">Completed Exercise</a>
-					<li class = "nav-item"></li>
+					</li>
+					<li class = "nav-item">
 						<a href="#" class = "nav-link">Favorited</a>
+					</li>
 				</ul>
 				<div class = "hamburger">
 					<span class = "bar"></span>

--- a/homepage/index.html
+++ b/homepage/index.html
@@ -23,13 +23,13 @@
 			<nav>
 				<ul class = "nav-menu">
 					<li class = "nav-item">
-						<a href="#" class = "nav-link">Home</a>
+						<a href="index.html" class = "nav-link">Home</a>
 					</li>
 					<li class = "nav-item">
-						<a href="#" class = "nav-link">Completed Exercise</a>
+						<a href="../completed.html" class = "nav-link">Completed Exercise</a>
 					</li>
 					<li class = "nav-item">
-						<a href="#" class = "nav-link">Favorited</a>
+						<a href="../favorite.html" class = "nav-link">Favorited</a>
 					</li>
 				</ul>
 				<div class = "hamburger">


### PR DESCRIPTION
This PR fixes an issue in the `ul` inside the `nav` element where the `a` tags were siblings of the `li` instead of being their children. Also enables the user to navigate the website using the navigation links.